### PR TITLE
fix when window-size is less than 767px

### DIFF
--- a/boilerplate/less/_media-queries.less
+++ b/boilerplate/less/_media-queries.less
@@ -53,6 +53,7 @@
         width: 93.75%;
         word-wrap: break-word;
         overflow: hidden;
+        padding-top: 0;
     }
 
     #main {


### PR DESCRIPTION
globalheader-containerの position は static なので padding は消すべき。
特にbackground-imageを指定したときその差が顕著になる。